### PR TITLE
Rename Site#{touch => touch_proxy} to avoid collision

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -28,7 +28,7 @@ class Site < ActiveRecord::Base
     proxy_pool_lock.lock do
       proxy_info = proxy_pool.range(0, 0, with_scores: true)
       proxy_id, proxy_ts = proxy_info.first
-      touch(proxy_id)
+      touch_proxy(proxy_id)
     end
     
     begin
@@ -73,7 +73,7 @@ class Site < ActiveRecord::Base
   
   def proxy_succeeded!(proxy)
     proxy_pool_lock.lock do
-      touch(proxy.id)
+      touch_proxy(proxy.id)
       proxy_successes.increment(proxy.id)
     end
   end
@@ -83,7 +83,7 @@ class Site < ActiveRecord::Base
     failure_threshold = conf['failure_threshold'].to_i
     num_failures = 0
     proxy_pool_lock.lock do
-      touch(proxy.id)
+      touch_proxy(proxy.id)
       num_failures = proxy_failures.increment(proxy.id)
     end
     if num_failures >= failure_threshold
@@ -99,7 +99,7 @@ class Site < ActiveRecord::Base
   end
 
   private
-  def touch(proxy_id)
+  def touch_proxy(proxy_id)
     proxy_pool[proxy_id] = Time.now.to_i unless proxy_id.nil?
   end
   


### PR DESCRIPTION
New name avoids overriding `ActiveRecord::Base#touch`