### PR TITLE
Integration testing round 1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'redis-objects'
 
 # Use resque to asyncronously run long-running jobs
 gem 'resque'
+gem 'resque-web', require: 'resque_web'
 
 # UI
 gem 'twitter-bootstrap-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,6 +221,12 @@ GEM
       redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
+    resque-web (0.0.6)
+      coffee-rails
+      jquery-rails
+      resque
+      sass-rails
+      twitter-bootstrap-rails
     rspec-core (3.2.1)
       rspec-support (~> 3.2.0)
     rspec-expectations (3.2.0)
@@ -311,6 +317,7 @@ DEPENDENCIES
   redis
   redis-objects
   resque
+  resque-web
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -6,11 +6,11 @@ class Proxy < ActiveRecord::Base
   include Concerns::SoftDeletable
 
   class << self
-    # Retrieve proxies from the database from a specific source that are
+    # Retrieve active proxies from the database from a specific source that are
     # currently unaffiliated with a site
     def retrieve(source:, site:, max_proxies:)
       assosciated_proxy_ids = ProxyPerformance.where(site: site).map(&:proxy_id)
-      self.where(source: source).reject { |p|
+      self.active.where(source: source).reject { |p|
         assosciated_proxy_ids.include? p.id
       }.take(max_proxies)
     end

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -29,6 +29,11 @@ class Proxy < ActiveRecord::Base
     end
   end
 
+  def transaction_options
+    return {isolation: :serializable} if Rails.env.production?
+    {}
+  end
+
   # Check to make sure the proxy is a candidate for being decomissioned.
   # If any sites are still using the proxy then leave it be.
   # If no sites are still using the proxy, soft-delete the proxy and perform
@@ -36,7 +41,7 @@ class Proxy < ActiveRecord::Base
   def decommission
     actually_decomission = false
 
-    self.transaction isolation: :serializable do
+    self.transaction(transaction_options) do
       if self.no_sites?
         # soft-delete the proxy so that nobody else tries to use it
         self.soft_delete

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -36,7 +36,7 @@ class Proxy < ActiveRecord::Base
   def decommission
     actually_decomission = false
 
-    self.transaction(Rails.config.default_transaction_options) do
+    self.transaction(Zartan::Application.config.default_transaction_options) do
       if self.no_sites?
         # soft-delete the proxy so that nobody else tries to use it
         self.soft_delete

--- a/app/models/proxy_performance.rb
+++ b/app/models/proxy_performance.rb
@@ -4,6 +4,20 @@ class ProxyPerformance < ActiveRecord::Base
 
   include Concerns::SoftDeletable
 
+  class << self
+    def restore_or_create(site:, proxy:)
+      perform = ProxyPerformance.find_or_create_by(
+        :site => site, :proxy => proxy
+      )
+      perform.deleted_at = nil
+      perform.times_succeeded = 0
+      perform.times_failed = 0
+      perform.reset_at = nil
+      perform.save
+      perform
+    end
+  end
+
   def increment(times_succeeded: 0, times_failed: 0)
     self.times_succeeded += times_succeeded
     self.times_failed += times_failed

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -102,8 +102,10 @@ class Site < ActiveRecord::Base
 
   # Take one or more proxies and add them to the site in both postgres and redis
   def add_proxies(*new_proxies)
-    restore_or_create_performances(new_proxies)
-    new_proxies.each {|p| self.enable_proxy p}
+    self.transaction(Rails.config.default_transaction_options) do
+      restore_or_create_performances(new_proxies)
+      new_proxies.each {|p| self.enable_proxy p}
+    end
   end
 
   # global_performance_analysis!()

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -102,7 +102,7 @@ class Site < ActiveRecord::Base
 
   # Take one or more proxies and add them to the site in both postgres and redis
   def add_proxies(*new_proxies)
-    self.transaction(Rails.config.default_transaction_options) do
+    self.transaction(Zartan::Application.config.default_transaction_options) do
       restore_or_create_performances(new_proxies)
       new_proxies.each {|p| self.enable_proxy p}
     end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -50,12 +50,12 @@ class Source < ActiveRecord::Base
   # Enqueues a ProvisionProxies job to create up to num_proxies new proxies.
   # Returns the number of new proxies that should be created after the provision
   def enqueue_provision(site:, num_proxies:)
-    return 0 if num_proxies <= 0 || self.proxies.length == self.max_proxies
+    return 0 if num_proxies <= 0 || self.proxies.active.length >= self.max_proxies
     desired_proxy_count = self.desired_proxy_count(num_proxies)
     Resque.enqueue(Jobs::ProvisionProxies,
       site.id, self.id, desired_proxy_count
     )
-    desired_proxy_count - self.proxies.length
+    desired_proxy_count - self.proxies.active.length
   end
 
   # Pure virtual function intended for child classes to
@@ -68,7 +68,7 @@ class Source < ActiveRecord::Base
   # return the number of proxies that would exist if up to num_requested
   # proxies were provisioned
   def desired_proxy_count(num_requested)
-    [self.max_proxies, self.proxies.length + num_requested].min
+    [self.max_proxies, self.proxies.active.length + num_requested].min
   end
 
   protected

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -120,8 +120,8 @@ class Source < ActiveRecord::Base
     # Each source gets its own queue for provisioning and decommissioning
     # proxies.  Get the name of that queue as a string
     def queue
-      # gsub keeps only the portion after the last slash
-      self.to_s.underscore.gsub(%r{^.*/(\w+)$}, '\1')
+      # Keeps only the portion after the last slash
+      self.name.underscore.split(%r[/]).last
     end
 
     def required_fields

--- a/app/models/sources/fog.rb
+++ b/app/models/sources/fog.rb
@@ -69,6 +69,10 @@ module Sources
       else
         add_error("Timed out when creating #{server.name}")
       end
+    rescue => e
+      # Since this is within a thread we do not want one thread to kill
+      # all the child threads.  Log the error in redis
+      add_error "#{e.inspect}\n#{e.backtrace.join("\n")}"
     end
 
     # save_server()

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,8 @@ module Zartan
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    # We should use serialized transactions by default
+    config.default_transaction_options = {isolation: :serializable}
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,4 +38,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Sqlite does not support serialized transactions
+  config.default_transaction_options = {}
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+require "resque_web"
+
 Rails.application.routes.draw do
   get  'v1/:site_name',                     to: 'api/version1#get_proxy', defaults: { older_than: -1 }
   post 'v1/:site_name/:proxy_id/succeeded', to: 'api/version1#report_result', succeeded: true
@@ -7,6 +9,8 @@ Rails.application.routes.draw do
   resources :sources, except: %i(destroy)
   resources :proxies, only: %i(show)
   
+  mount ResqueWeb::Engine => "/resque_web"
+
   get 'config',      to: 'config#show', as: :config
   post 'config/set', to: 'config#set', as: :config_set
   

--- a/lib/jobs/decommission_proxy.rb
+++ b/lib/jobs/decommission_proxy.rb
@@ -1,10 +1,6 @@
 module Jobs
   class DecommissionProxy
     class << self
-      def queue
-        :default
-      end
-
       def perform(proxy_id)
         proxy = Proxy.find proxy_id
         proxy.decommission

--- a/lib/jobs/decommission_proxy.rb
+++ b/lib/jobs/decommission_proxy.rb
@@ -1,6 +1,10 @@
 module Jobs
   class DecommissionProxy
     class << self
+      def queue
+        :default
+      end
+
       def perform(proxy_id)
         proxy = Proxy.find proxy_id
         proxy.decommission

--- a/lib/jobs/global_performance_analyzer.rb
+++ b/lib/jobs/global_performance_analyzer.rb
@@ -1,6 +1,10 @@
 module Jobs
   class GlobalPerformanceAnalyzer
     class << self
+      def queue
+        :default
+      end
+
       def perform
         threads = Site.all.map do |site|
           Thread.new {site.global_performance_analysis!}

--- a/lib/jobs/provision_proxies.rb
+++ b/lib/jobs/provision_proxies.rb
@@ -1,9 +1,14 @@
 module Jobs
   class ProvisionProxies
     class << self
+      def queue
+        :default
+      end
+
       def perform(site_id, source_id, desired_proxy_count)
         source = Source.find source_id
-        num_proxies = desired_proxy_count - source.proxies.length
+        num_proxies = desired_proxy_count - source.proxies.active.length
+        byebug
         if num_proxies > 0
           site = Site.find site_id
           proxies = source.provision_proxies num_proxies, site

--- a/lib/jobs/provision_proxies.rb
+++ b/lib/jobs/provision_proxies.rb
@@ -1,14 +1,9 @@
 module Jobs
   class ProvisionProxies
     class << self
-      def queue
-        :default
-      end
-
       def perform(site_id, source_id, desired_proxy_count)
         source = Source.find source_id
         num_proxies = desired_proxy_count - source.proxies.active.length
-        byebug
         if num_proxies > 0
           site = Site.find site_id
           proxies = source.provision_proxies num_proxies, site

--- a/lib/jobs/targeted_performance_analyzer.rb
+++ b/lib/jobs/targeted_performance_analyzer.rb
@@ -1,6 +1,10 @@
 module Jobs
   class TargetedPerformanceAnalyzer
     class << self
+      def queue
+        :default
+      end
+
       def perform(site_id, proxy_id)
         site = Site.find(site_id)
         proxy = Proxy.find(proxy_id)

--- a/lib/proxy_requestor.rb
+++ b/lib/proxy_requestor.rb
@@ -51,12 +51,15 @@ class ProxyRequestor
     calculate_proxies_needed
   end
 
+  def num_proxies_by_performance(perform)
+    return @proxies_needed.to_f if @ratio_sum == 0
+    (@proxies_needed * perform.success_ratio / @ratio_sum).round
+  end
+
   # Takes existing proxies from the database and adds them to the site
   # Returns the number of proxies that we should ask the source to provision
   def add_existing_proxies(perform)
-    num_proxies_to_request = (
-      @proxies_needed * perform.success_ratio / @ratio_sum
-    ).round
+    num_proxies_to_request = num_proxies_by_performance perform
     proxies = Proxy.retrieve(
       source: perform.source,
       site: site,

--- a/lib/proxy_requestor.rb
+++ b/lib/proxy_requestor.rb
@@ -52,8 +52,12 @@ class ProxyRequestor
   end
 
   def num_proxies_by_performance(perform)
-    return @proxies_needed.to_f if @ratio_sum == 0
-    (@proxies_needed * perform.success_ratio / @ratio_sum).round
+    if @ratio_sum <= 0.0
+      num_proxies = @proxies_needed.to_f / Source.count
+    else
+      num_proxies = @proxies_needed.to_f * perform.success_ratio / @ratio_sum
+    end
+    num_proxies.round
   end
 
   # Takes existing proxies from the database and adds them to the site

--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -1,0 +1,3 @@
+require 'resque/tasks'
+
+task 'resque:setup' => :environment

--- a/spec/factories/proxy_performance.rb
+++ b/spec/factories/proxy_performance.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :proxy_performance do
+    association :proxy, factory: :proxy, host: 'performance_host'
+    association :site, factory: :site, name: 'performance_site'
+  end
+end

--- a/spec/lib/proxy_requestor_spec.rb
+++ b/spec/lib/proxy_requestor_spec.rb
@@ -57,12 +57,31 @@ RSpec.describe ProxyRequestor do
     end
   end
 
-  context '#add_existing_proxies' do
-    before :each do
+  context '#num_proxies_by_performance' do
+    it 'evenly divides the proxies if we have no statistics' do
+      requestor.instance_variable_set(:@ratio_sum, 0.0)
+      requestor.instance_variable_set(:@proxies_needed, 7)
+      expect(Source).to receive(:count).and_return(2)
+
+      expect(requestor.send(:num_proxies_by_performance, double)).to eq 4
+    end
+
+    it 'calculates the proxies needed based on statistics' do
+      perform = double(:success_ratio => 0.6666667)
       requestor.instance_variable_set(:@proxies_needed, 100)
       requestor.instance_variable_set(:@ratio_sum, 1.0)
+
+      expect(requestor.send(:num_proxies_by_performance, perform)).to eq 67
+    end
+  end
+
+  context '#add_existing_proxies' do
+    before :each do
       allow(requestor).to receive(:site).and_return(site)
       expect(site).to receive(:add_proxies)
+      requestor.instance_variable_set(:@proxies_needed, 100)
+      requestor.instance_variable_set(:@ratio_sum, 1.0)
+      expect(requestor).to receive(:num_proxies_by_performance).and_return(75)
     end
 
     it 'does not need to partition more proxies' do

--- a/spec/models/proxy_performance_spec.rb
+++ b/spec/models/proxy_performance_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ProxyPerformance, type: :model do
     end
 
     it 'restores an existing ProxyPerformance object' do
-      proxy_performance.touch :deleted_at
+      proxy_performance.soft_delete
       proxy_performance.save
 
       returned_perform = ProxyPerformance.restore_or_create(

--- a/spec/models/proxy_performance_spec.rb
+++ b/spec/models/proxy_performance_spec.rb
@@ -3,8 +3,9 @@ require 'rails_helper'
 RSpec.describe ProxyPerformance, type: :model do
   let(:site) {create(:site)}
   let(:proxy) {create(:proxy)}
+
   let(:proxy_performance) do
-    @proxy_performance ||= ProxyPerformance.create(
+    ProxyPerformance.find_or_create_by(
       :proxy => proxy, :site => site
     )
   end
@@ -31,7 +32,7 @@ RSpec.describe ProxyPerformance, type: :model do
     end
 
     it 'creates a new ProxyPerformance object' do
-      @proxy_performance = ProxyPerformance.restore_or_create(
+      ProxyPerformance.restore_or_create(
         site: site, proxy: proxy
       )
     end

--- a/spec/models/proxy_spec.rb
+++ b/spec/models/proxy_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Proxy, type: :model do
 
     it 'queues the decommission of an unused proxy' do
       expect(proxy).to receive(:no_sites?).and_return(true)
-      expect(Resque).to receive(:enqueue)
+      expect(Resque).to receive(:enqueue_to)
 
       proxy.queue_decommission
     end

--- a/spec/models/proxy_spec.rb
+++ b/spec/models/proxy_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Proxy, type: :model do
   end
   let(:site) {create(:site)}
   let(:proxy_performance) do
-    ProxyPerformance.create(:site => site, :proxy => proxy)
+    create(:proxy_performance, :site => site, :proxy => proxy)
   end
 
   context "SoftDeletable" do

--- a/spec/models/proxy_spec.rb
+++ b/spec/models/proxy_spec.rb
@@ -50,6 +50,17 @@ RSpec.describe Proxy, type: :model do
       expect(proxies).to eq [proxy]
     end
 
+    it 'ignores soft deleted proxies' do
+      proxy.soft_delete
+      proxy.save
+      proxies = Proxy.retrieve(
+        :source => source,
+        :site => site,
+        :max_proxies => 5
+      )
+      expect(proxies).to eq []
+    end
+
     it 'ignores proxies that have been removed from a site' do
       proxy_performance.soft_delete
       proxy_performance.save

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Site, type: :model do
   let(:proxy) {create(:proxy)}
   let(:proxy2) {create(:proxy, :host => 'host2')}
   let(:proxy_performance) do
-    ProxyPerformance.create(:proxy => proxy, :site => site)
+    create(:proxy_performance, :proxy => proxy, :site => site)
   end
 
   describe "redis interactions" do

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Site, type: :model do
   let(:site) {create(:site)}
   let(:proxy) {create(:proxy)}
+  let(:proxy2) {create(:proxy, :host => 'host2')}
   let(:proxy_performance) do
     ProxyPerformance.create(:proxy => proxy, :site => site)
   end
@@ -182,12 +183,11 @@ RSpec.describe Site, type: :model do
     end
 
     it "should add proxies to both redis and postgres" do
-      expect(site).to receive(:enable_proxy)
+      expect(site).to receive(:restore_or_create_performances)
+      expect(site).to receive(:enable_proxy).twice
+      expect(site).to receive(:transaction).and_yield
 
-      site.add_proxies(proxy)
-
-      expect(ProxyPerformance.where(:proxy => proxy, :site => site).exists?).
-        to be_truthy
+      site.add_proxies(proxy, proxy2)
     end
 
     context '#generate_proxy_report' do
@@ -238,6 +238,14 @@ RSpec.describe Site, type: :model do
     it "should run a performance analysis on a single proxy" do
       expect(site).to receive(:disable_proxy_if_bad)
       site.proxy_performance_analysis! proxy
+    end
+  end
+
+  context '#restore_or_create_performances' do
+    it 'restores or creates multiple proxies' do
+      expect(ProxyPerformance).to receive(:restore_or_create).twice
+
+      site.send(:restore_or_create_performances, [proxy, proxy2])
     end
   end
 
@@ -316,7 +324,8 @@ RSpec.describe Site, type: :model do
   context '#update_long_term_performance' do
     it 'updates long term performance of a site/proxy combination from redis' do
       proxy_performance.save
-      expect(ProxyPerformance).to receive(:find).and_return(proxy_performance)
+      expect(ProxyPerformance).to receive(:find_or_create_by).
+        and_return(proxy_performance)
       times_succeeded = 20
       times_failed = 3
       report = Site::PerformanceReport.new(times_succeeded, times_failed)

--- a/spec/models/sources/digital_ocean_spec.rb
+++ b/spec/models/sources/digital_ocean_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Sources::DigitalOcean, type: :model do
   let(:site) {create(:site)}
   let(:proxy) {create(:proxy)}
   let(:proxy_performance) do
-    ProxyPerformance.create(:proxy => proxy, :site => site)
+    create(:proxy_performance, :proxy => proxy, :site => site)
   end
 
   context '#validate_config!' do

--- a/spec/models/sources/fog_spec.rb
+++ b/spec/models/sources/fog_spec.rb
@@ -53,5 +53,12 @@ RSpec.describe Sources::DigitalOcean, type: :model do
 
       source.send(:provision_proxy, site)
     end
+
+    it 'catches errors' do
+      expect(source).to receive(:validate_config!).and_raise(StandardError.new)
+      expect(source).to receive(:add_error)
+
+      source.send(:provision_proxy, site)
+    end
   end
 end


### PR DESCRIPTION
Add resque-web
Add queue to Resque classes
Each source has its own queue intended to have exactly 1 worker
More checks to make sure we only get active proxies when we intend to get active proxies.
Serialized transactions only for production
If we don't have any statistics when requesting proxies from the database, divide the proxies evenly among sources