### PR TITLE
Integration testing round 2

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -109,15 +109,15 @@ class Site < ActiveRecord::Base
   end
 
   # global_performance_analysis!()
-  # Run a performance analysis on all proxies associated with the site.
-  # Consistently successful proxies stay in service while unsuccessful
+  # Run a performance analysis on all proxies currently associated with the
+  # site. Consistently successful proxies stay in service while unsuccessful
   # proxies get pruned.
   # Gets more proxies if there are too few proxies afterwards.
   # Parameters:
   #   None
   def global_performance_analysis!
-    self.proxies.each do |proxy|
-      disable_proxy_if_bad proxy
+    self.proxy_performances.active.each do |proxy_performance|
+      disable_proxy_if_bad proxy_performance.proxy
     end
     request_more_proxies
   end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -17,6 +17,13 @@ class Source < ActiveRecord::Base
     end
   end
 
+  # Dummy class used to add proxies to the database without adding them to a
+  # site
+  class NoSite
+    def self.add_proxies(*args)
+    end
+  end
+
   def config
     @config ||= JSON.parse(read_attribute(:config))
   end
@@ -75,7 +82,7 @@ class Source < ActiveRecord::Base
 
   # Helper method for child classes to use to add a new proxy to the database
   # when the host and port have been created
-  def add_proxy(host, port, site)
+  def add_proxy(host, port, site = NoSite)
     proxy = Proxy.restore_or_initialize host: host, port: port
 
     return if fix_source_conflicts(proxy).conflict_exists?

--- a/app/models/sources/digital_ocean.rb
+++ b/app/models/sources/digital_ocean.rb
@@ -14,6 +14,7 @@ module Sources
 
     ID_TYPES = ['image', 'flavor', 'region']
 
+    # Connect to Digital Ocean to make sure our config is valid
     def validate_config!
       valid = false
       begin

--- a/app/models/sources/digital_ocean.rb
+++ b/app/models/sources/digital_ocean.rb
@@ -27,6 +27,14 @@ module Sources
 
     private
 
+    # server_is_proxy_type?(server)
+    # given a server, determine if it is running a proxy
+    def server_is_proxy_type?(server)
+      return server.image_id == self.image_id \
+        && server.region_id == self.region_id \
+        && server.flavor_id == self.flavor_id
+    end
+
     def connection
       @connection ||= ::Fog::Compute.new(
         :provider => 'DigitalOcean',

--- a/app/models/sources/digital_ocean.rb
+++ b/app/models/sources/digital_ocean.rb
@@ -124,6 +124,10 @@ module Sources
         flavor_id: flavor_id,
         region_id: region_id
       )
+    # Generally get this error when we've hit our limit on # of servers
+    rescue Excon::Errors::Forbidden => e
+      add_error(JSON.parse(e.response.body)['error_message'])
+      NoServer
     end
   end
 end

--- a/app/models/sources/fog.rb
+++ b/app/models/sources/fog.rb
@@ -40,7 +40,26 @@ module Sources
       server.destroy
     end
 
+    # find_orphaned_servers!()
+    # Searches through the list of servers to find any servers that have been
+    # created, but fell through the cracks getting added to the database
+    def find_orphaned_servers!
+      connection.servers.each do |server|
+        if server_is_proxy_type?(server) \
+          && !Proxy.active.where(:host => server.public_ip_address).exists? \
+
+          save_server server
+        end
+      end
+    end
+
     protected
+
+    # server_is_proxy_type?(server)
+    # given a server, determine if it is running a proxy
+    def server_is_proxy_type?(server)
+      raise NotImplementedError, "Implement #{__callee__} in #{self.class.to_s}"
+    end
 
     # server_by_proxy(proxy)
     # Searches the service for the Fog server object that the proxy runs on
@@ -52,6 +71,12 @@ module Sources
     # Creates a Fog server.
     # This server object only needs to be initialized, not necessarily ready
     def create_server
+      raise NotImplementedError, "Implement #{__callee__} in #{self.class.to_s}"
+    end
+
+    # connection()
+    # Returns the connection object for the source
+    def connection
       raise NotImplementedError, "Implement #{__callee__} in #{self.class.to_s}"
     end
 
@@ -77,7 +102,7 @@ module Sources
 
     # save_server()
     # Wrapper for Source.add_proxy
-    def save_server(server, site)
+    def save_server(server, site = NoSite)
       add_proxy(server.public_ip_address, config['proxy_port'], site)
     end
   end

--- a/app/models/sources/fog.rb
+++ b/app/models/sources/fog.rb
@@ -89,6 +89,8 @@ module Sources
       return unless validate_config!
 
       server = create_server
+
+      return if server == NoServer
       if server.wait_for { ready? }
         save_server server, site
       else

--- a/app/models/sources/fog.rb
+++ b/app/models/sources/fog.rb
@@ -91,12 +91,12 @@ module Sources
     # provision_proxy()
     # Provision a single proxy on the cloud and add it to site when ready
     def provision_proxy(site)
-      # the config is invalid. The child class logs the error
+      # The config is invalid. The child class logs the error
       return unless validate_config!
 
-      # Return If we didn't get a server. The child class logs the error
       server = create_server
 
+      # Return If we didn't get a server. The child class logs the error
       return if server == NoServer
       if server.wait_for { ready? }
         save_server server, site

--- a/app/models/sources/fog.rb
+++ b/app/models/sources/fog.rb
@@ -80,14 +80,21 @@ module Sources
       raise NotImplementedError, "Implement #{__callee__} in #{self.class.to_s}"
     end
 
+    # validate_config!()
+    # Connect to the cloud service to make sure our config is valid
+    def validate_config!
+      raise NotImplementedError, "Implement #{__callee__} in #{self.class.to_s}"
+    end
+
     private
 
     # provision_proxy()
     # Provision a single proxy on the cloud and add it to site when ready
     def provision_proxy(site)
-      # Return If we didn't get a server. The child class logs the error
+      # the config is invalid. The child class logs the error
       return unless validate_config!
 
+      # Return If we didn't get a server. The child class logs the error
       server = create_server
 
       return if server == NoServer

--- a/spec/factories/source.rb
+++ b/spec/factories/source.rb
@@ -9,8 +9,11 @@ FactoryGirl.define do
         'client_id' => "DEADBEEF_ID",
         'api_key' => "DEADBEEF_KEY",
         'image_name' => "image",
+        'image_id' => 1,
         'flavor_name' => "1337MB",
+        'flavor_id' => 2,
         'region_name' => "Nowhere 3",
+        'region_id' => 3,
         'proxy_port' => 2341
       }
     end

--- a/spec/models/sources/digital_ocean_spec.rb
+++ b/spec/models/sources/digital_ocean_spec.rb
@@ -178,6 +178,16 @@ RSpec.describe Sources::DigitalOcean, type: :model do
 
       expect(source.send(:create_server)).to be server
     end
+
+    it 'recovers when we have reached our droplet limit' do
+      response = double(:body => ({'error_message' => "droplet limit"}.to_json))
+      expect(source).to receive(:connection).and_raise(
+        Excon::Errors::Forbidden.new("Error", nil, response)
+      )
+      expect(source).to receive(:add_error).with("droplet limit")
+
+      expect(source.send(:create_server)).to be Sources::Fog::NoServer
+    end
   end
 
 end

--- a/spec/models/sources/digital_ocean_spec.rb
+++ b/spec/models/sources/digital_ocean_spec.rb
@@ -33,6 +33,45 @@ RSpec.describe Sources::DigitalOcean, type: :model do
     end
   end
 
+  context '#server_is_proxy_type?' do
+    it 'identifies a server that runs a proxy' do
+      server = double(
+        image_id: source.config['image_id'],
+        flavor_id: source.config['flavor_id'],
+        region_id: source.config['region_id']
+      )
+
+      expect(source.send(:server_is_proxy_type?, server)).to be_truthy
+    end
+
+    it 'identifies a server that is in a different region' do
+      server = double(
+        image_id: source.config['image_id'],
+        flavor_id: source.config['flavor_id'],
+        region_id: nil
+      )
+      expect(source.send(:server_is_proxy_type?, server)).to be_falsey
+    end
+
+    it 'identifies a server that has a different flavor' do
+      server = double(
+        image_id: source.config['image_id'],
+        flavor_id: nil,
+        region_id: source.config['region_id']
+      )
+      expect(source.send(:server_is_proxy_type?, server)).to be_falsey
+    end
+
+    it 'identifies a server that has a different image' do
+      server = double(
+        image_id: nil,
+        flavor_id: source.config['flavor_id'],
+        region_id: source.config['region_id']
+      )
+      expect(source.send(:server_is_proxy_type?, server)).to be_falsey
+    end
+  end
+
   context '#server_by_proxy' do
     it 'retrieves a server that matches the proxy' do
       expect(source).to receive(:validate_config!).and_return(true)
@@ -69,6 +108,7 @@ RSpec.describe Sources::DigitalOcean, type: :model do
     end
 
     it 'translates name to id if the id is not saved' do
+      source.config.delete 'image_id'
       expect(source).to receive(:names_to_ids) {source.config['image_id'] = 1}
 
       expect(source.image_id).to eq 1

--- a/spec/models/sources/fog_spec.rb
+++ b/spec/models/sources/fog_spec.rb
@@ -67,6 +67,14 @@ RSpec.describe Sources::DigitalOcean, type: :model do
       source.send(:provision_proxy, site)
     end
 
+    it 'silently ignores when the client class returns a NoServer object' do
+      expect(source).to receive(:validate_config!).and_return(true)
+      server = Sources::Fog::NoServer
+      expect(source).to receive(:create_server).and_return(server)
+
+      source.send(:provision_proxy, site)
+    end
+
     it 'logs an error when the server times out' do
       expect(source).to receive(:validate_config!).and_return(true)
       server = double(:wait_for => false, :name => 'foo')


### PR DESCRIPTION
Only run the global performance analysis on active proxy/site relationships
Add ability to find servers on digital ocean that were not added to the database
Recover gracefully when we reach our droplet limit on Digital Ocean
