### PR TITLE
Global performance analysis doesn't load classes properly when multithreaded

### DIFF
--- a/lib/jobs/global_performance_analyzer.rb
+++ b/lib/jobs/global_performance_analyzer.rb
@@ -6,10 +6,9 @@ module Jobs
       end
 
       def perform
-        threads = Site.all.map do |site|
-          Thread.new {site.global_performance_analysis!}
+        Site.all.each do |site|
+          site.global_performance_analysis!
         end
-        threads.each(&:join)
       end
     end
   end


### PR DESCRIPTION
There really is no reason for the global performance analyzer to be multithreaded.  It does a lot of calls to the database, but if it actually decommissions a proxy or provisions more proxies it triggers a new job to do that task.  Meanwhile, keeping the job multithreaded triggers circular dependency errors.