### PR TITLE
Find orphaned servers after multi-threaded provisioning step

### DIFF
--- a/app/models/sources/digital_ocean.rb
+++ b/app/models/sources/digital_ocean.rb
@@ -33,7 +33,8 @@ module Sources
     def server_is_proxy_type?(server)
       return server.image_id == self.image_id \
         && server.region_id == self.region_id \
-        && server.flavor_id == self.flavor_id
+        && server.flavor_id == self.flavor_id \
+        && server.state == "active"
     end
 
     def connection

--- a/spec/models/sources/digital_ocean_spec.rb
+++ b/spec/models/sources/digital_ocean_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe Sources::DigitalOcean, type: :model do
       server = double(
         image_id: source.config['image_id'],
         flavor_id: source.config['flavor_id'],
-        region_id: source.config['region_id']
+        region_id: source.config['region_id'],
+        state: "active"
       )
 
       expect(source.send(:server_is_proxy_type?, server)).to be_truthy
@@ -48,7 +49,8 @@ RSpec.describe Sources::DigitalOcean, type: :model do
       server = double(
         image_id: source.config['image_id'],
         flavor_id: source.config['flavor_id'],
-        region_id: nil
+        region_id: nil,
+        state: "active"
       )
       expect(source.send(:server_is_proxy_type?, server)).to be_falsey
     end
@@ -57,7 +59,8 @@ RSpec.describe Sources::DigitalOcean, type: :model do
       server = double(
         image_id: source.config['image_id'],
         flavor_id: nil,
-        region_id: source.config['region_id']
+        region_id: source.config['region_id'],
+        state: "active"
       )
       expect(source.send(:server_is_proxy_type?, server)).to be_falsey
     end
@@ -66,8 +69,20 @@ RSpec.describe Sources::DigitalOcean, type: :model do
       server = double(
         image_id: nil,
         flavor_id: source.config['flavor_id'],
-        region_id: source.config['region_id']
+        region_id: source.config['region_id'],
+        state: "active"
       )
+      expect(source.send(:server_is_proxy_type?, server)).to be_falsey
+    end
+
+    it 'identifies a server that is not active' do
+      server = double(
+        image_id: source.config['image_id'],
+        flavor_id: source.config['flavor_id'],
+        region_id: source.config['region_id'],
+        state: "new"
+      )
+
       expect(source.send(:server_is_proxy_type?, server)).to be_falsey
     end
   end

--- a/spec/models/sources/fog_spec.rb
+++ b/spec/models/sources/fog_spec.rb
@@ -7,12 +7,15 @@ RSpec.describe Sources::DigitalOcean, type: :model do
     it 'provisions multiple proxies' do
       expect(source).to receive(:validate_config!).and_return(true)
       expect(source).to receive(:provision_proxy).exactly(3).times
+      expect(source).to receive(:find_orphaned_servers!)
+
       source.provision_proxies(3, double)
     end
 
     it 'does nothing if the config is invalid' do
       expect(source).to receive(:validate_config!).and_return(false)
       expect(source).to receive(:provision_proxy).never
+
       source.provision_proxies(3, double)
     end
   end


### PR DESCRIPTION
I've encountered 2 scenarios where digital ocean servers get orphaned:
1. Development DB locks in multithreaded context, preventing the proxy from being added
2. Digital Ocean times out provisioning the server.  This seems especially common in the NYC2 region.

If we don't automatically recover these orphaned servers as a part of our normal process, then we will quickly max the number of droplets we can create even though we have little to no proxies in our database.