### PR TITLE
Site performance analyzer

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -42,6 +42,9 @@ class Site < ActiveRecord::Base
       threshold_ts = (Time.now - older_than.seconds).to_i
       if proxy_ts.nil?
         # We didn't find a proxy
+        # Enqueue the performance analyzer for the site so that we may have
+        # a proxy by the time the client requests a proxy again.
+        Resque.enqueue(Jobs::SitePerformanceAnalyzer, self.id)
         Proxy::NoProxy
       elsif proxy_ts > threshold_ts
         # The proxy we found was too recently used.

--- a/lib/jobs/site_performance_analyzer.rb
+++ b/lib/jobs/site_performance_analyzer.rb
@@ -1,0 +1,14 @@
+module Jobs
+  class SitePerformanceAnalyzer
+    class << self
+      def queue
+        :default
+      end
+
+      def perform(site_id)
+        site = Site.find site_id
+        site.global_performance_analysis!
+      end
+    end
+  end
+end

--- a/spec/lib/jobs/site_performance_analyzer_spec.rb
+++ b/spec/lib/jobs/site_performance_analyzer_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Jobs::SitePerformanceAnalyzer do
+  context '#perform' do
+    let(:site) {create(:site)}
+
+    it 'does a performance analysis on a single site' do
+      expect(Site).to receive(:find).and_return(site)
+      expect(site).to receive(:global_performance_analysis!)
+
+      Jobs::SitePerformanceAnalyzer.perform site.id
+    end
+  end
+end


### PR DESCRIPTION
Create a new job, SitePerformanceAnalyzer, to run a performance analysis on a single site in isolation.  This is intended to be queued when zartan receives its first get request for a new site.  Otherwise the client will have to wait until the GlobalPerformanceAnalyzer happens to be triggered.