### PR TITLE
Always bad proxies never get deleted.

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -139,7 +139,7 @@ class Site < ActiveRecord::Base
   # Parameters:
   #   proxy: The prxoy whose performance is being analyzed
   def proxy_performance_analysis!(proxy)
-    disable_proxy_if_bad proxy
+    disable_proxy_if_bad proxy, trust_sample_size: true
     request_more_proxies
   end
 
@@ -163,9 +163,9 @@ class Site < ActiveRecord::Base
   # proxies get pruned.
   # Parameters:
   #   proxy: The prxoy to get a report on
-  def disable_proxy_if_bad(proxy)
+  def disable_proxy_if_bad(proxy, trust_sample_size: false)
     report = generate_proxy_report proxy
-    if large_enough_sample?(report) \
+    if (trust_sample_size || large_enough_sample?(report)) \
       && report.times_succeeded.to_f / report.total < success_ratio_threshold
 
       self.disable_proxy proxy

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -334,6 +334,16 @@ RSpec.describe Site, type: :model do
 
       site.send(:disable_proxy_if_bad, proxy)
     end
+
+    it "should ignore sample size when requested" do
+      report = Site::PerformanceReport.new(10, 100)
+      expect(site).to receive(:generate_proxy_report).and_return(report)
+      expect(site).to receive(:success_ratio_threshold).and_return(0.25)
+      expect(site).to receive(:disable_proxy)
+      expect(site).to receive(:large_enough_sample?).never
+
+      site.send(:disable_proxy_if_bad, proxy, {trust_sample_size: true})
+    end
   end
 
   context '#large_enough_sample?' do


### PR DESCRIPTION
Depends on #42 

The targeted performance analyzer should always assume it has enough data samples to be statistically significant.  The global performance analyzer needs to evaluate its success + failure counts to determine statistical significance.