### PR TITLE
Include timestamp in name for Digital Ocean proxies

### DIFF
--- a/app/models/sources/digital_ocean.rb
+++ b/app/models/sources/digital_ocean.rb
@@ -119,8 +119,9 @@ module Sources
     end
 
     def create_server
+      timestamp = Time.now.strftime("%Y.%m.%d-%H.%M.%S")
       connection.servers.create(
-        name: "proxy-#{SecureRandom.uuid}",
+        name: "proxy-#{timestamp}-#{SecureRandom.uuid}",
         image_id: image_id,
         flavor_id: flavor_id,
         region_id: region_id


### PR DESCRIPTION
In order to make them easier to identify (and potential issues easier to debug), the names for `Source::DigitalOcean` proxies should include the current timestamp when they're provisioned.