### PR TITLE
Feature/purge joyent

### DIFF
--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -20,7 +20,7 @@ class Source < ActiveRecord::Base
   def config
     @config ||= JSON.parse(read_attribute(:config))
   end
-  
+
   def config=(new_value)
     @config = new_value
   end
@@ -28,7 +28,7 @@ class Source < ActiveRecord::Base
   def save_config
     write_attribute(:config, @config.to_json) if @config
   end
-  
+
   SourceConflict = Struct.new(:conflict_exists?)
 
   # Pure virtual function intended for child classes to free the proxy resources
@@ -75,6 +75,11 @@ class Source < ActiveRecord::Base
   # Entry point for child classes to note that a proxy's server is about
   # to be decommissioned.
   def pending_decommission(proxy)
+  end
+
+  # Pure virtual function intended for child classes to free all proxy resources
+  def purge_servers
+    raise NotImplementedError, "Implement #{__callee__} in #{self.class.to_s}"
   end
 
   protected
@@ -134,7 +139,7 @@ class Source < ActiveRecord::Base
     def required_fields
       raise NotImplementedError, "Implement #{__callee__} in #{self.to_s}"
     end
-    
+
     def display_name
       # The default implementation of ##display_name takes the name of the class
       # minus any module names, and attempts to convert it into mutliple words

--- a/app/models/sources/fog.rb
+++ b/app/models/sources/fog.rb
@@ -111,7 +111,7 @@ module Sources
     # owned by this source
     def number_of_remote_servers
       connection.servers.inject(0) do |sum, s|
-        sum += 1 if server_is_proxy_type?(s) 
+        sum += 1 if server_is_proxy_type?(s)
         sum
       end
     end
@@ -154,6 +154,12 @@ module Sources
     # validate_config!()
     # Connect to the cloud service to make sure our config is valid
     def validate_config!
+      raise NotImplementedError, "Implement #{__callee__} in #{self.class.to_s}"
+    end
+
+    # purge_servers()
+    # Pure virtual function intended for child classes to free all proxy resources
+    def purge_servers
       raise NotImplementedError, "Implement #{__callee__} in #{self.class.to_s}"
     end
 

--- a/app/models/sources/joyent.rb
+++ b/app/models/sources/joyent.rb
@@ -35,6 +35,7 @@ module Sources
       connection.servers.select do |s|
         puts("deleteing #{s.name} (id: #{s.id})")
         puts(connection.delete_machine(s.id))
+      end
     end
 
     private

--- a/app/models/sources/joyent.rb
+++ b/app/models/sources/joyent.rb
@@ -31,7 +31,7 @@ module Sources
     # Each machine found will be delete.
     def purge_servers(captcha=nil)
       if captcha.nil?
-        puts("What is 1 + 2 + 3 + 4?")
+        puts("What is 1 + 2 + 3 + 4? Put answer as a parameter.")
       elsif captcha == 10
         connection.servers.select do |s|
           puts("deleteing #{s.name} (id: #{s.id})")

--- a/app/models/sources/joyent.rb
+++ b/app/models/sources/joyent.rb
@@ -30,11 +30,11 @@ module Sources
     # provided with this source. Each proxy found will then be delete.
     # To selecte a different datacenter, a new source must be created or you
     # can edit the source with a new datacenter.
-    def purge
+    # Pure virtual function intended for child classes to free all proxy resources
+    def purge_servers(captcha=false)
       connection.servers.select do |s|
-        puts('check if proxy')
-        puts('if proxy delete/decomision')
-      end
+        puts("deleteing #{s.name} (id: #{s.id})")
+        puts(connection.delete_machine(s.id))
     end
 
     private

--- a/app/models/sources/joyent.rb
+++ b/app/models/sources/joyent.rb
@@ -29,12 +29,19 @@ module Sources
     # Connnect to Joyent and find all of the machines with that combination of
     # user and datacenter that is provided with each source object source.
     # Each machine found will be delete.
-    def purge_servers(captcha=false)
-      connection.servers.select do |s|
-        puts("deleteing #{s.name} (id: #{s.id})")
-        connection.delete_machine(s.id)
+    def purge_servers(captcha=nil)
+      if captcha.nil?
+        puts("What is 1 + 2 + 3 + 4?")
+      elsif captcha == 10
+        connection.servers.select do |s|
+          puts("deleteing #{s.name} (id: #{s.id})")
+          connection.delete_machine(s.id)
+        end
+        return true
+      else
+        puts("WRONG!")
       end
-      return true
+      return false
     end
 
     private

--- a/app/models/sources/joyent.rb
+++ b/app/models/sources/joyent.rb
@@ -26,16 +26,15 @@ module Sources
       return false
     end
 
-    # Connnect to Joyent and find all of the proxies with the datacenter
-    # provided with this source. Each proxy found will then be delete.
-    # To selecte a different datacenter, a new source must be created or you
-    # can edit the source with a new datacenter.
-    # Pure virtual function intended for child classes to free all proxy resources
+    # Connnect to Joyent and find all of the machines with that combination of
+    # user and datacenter that is provided with each source object source.
+    # Each machine found will be delete.
     def purge_servers(captcha=false)
       connection.servers.select do |s|
         puts("deleteing #{s.name} (id: #{s.id})")
-        puts(connection.delete_machine(s.id))
+        connection.delete_machine(s.id)
       end
+      return true
     end
 
     private

--- a/app/models/sources/joyent.rb
+++ b/app/models/sources/joyent.rb
@@ -26,6 +26,17 @@ module Sources
       return false
     end
 
+    # Connnect to Joyent and find all of the proxies with the datacenter
+    # provided with this source. Each proxy found will then be delete.
+    # To selecte a different datacenter, a new source must be created or you
+    # can edit the source with a new datacenter.
+    def purge
+      connection.servers.select do |s|
+        puts('check if proxy')
+        puts('if proxy delete/decomision')
+      end
+    end
+
     private
 
     # server_is_proxy_type?(server)
@@ -62,8 +73,9 @@ module Sources
       )
     # Generally get this error when we've hit our limit on # of servers
     # but Joyent will produce errors here as well if form data is incorrect
-    rescue Excon::Errors::Forbidden => e
-      add_error(JSON.parse(e.response.body)['error_message'])
+    rescue => e
+      puts(e)
+      add_error(e.message)
       NoServer
     end
   end


### PR DESCRIPTION
Deletes all of the machines from a source you run the purge_servers() function on.

Example usage:
- grab a Joyent Source
  > \> j = Source::Joyent.first

- run purge_servers through your source
  > \> j.purse_servers
  > What is 1 + 2 + 3 + 4? Put answer as a parameter.
  >  => false

- put answer in as parameter
  > \> j.purge_servers(1)
  > WRONG!
  >  => false 
  > \> j.purge_servers(10)
  > deleteing 0a8bb2c (id: 9e16b64f-c80e-6327-a5d1-e6961b7c1722)
  > deleteing 716bfc8 (id: dbb73bc0-117e-c9a9-d781-cf8d792c6fd3)
  >  => true

Note: Resque isn't working on my machine again (rebooted) so I am unable to test with any of the background processes. The function does what is needed but I am unsure if any of the background processes would take care of making sure the database is consistent or not.