### PR TITLE
Add Static Source

### DIFF
--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -81,11 +81,13 @@ class Source < ActiveRecord::Base
 
   # Helper method for child classes to use to add a new proxy to the database
   # when the host and port have been created
-  def add_proxy(host, port, site = Site::NoSite)
+  def add_proxy(host, port, username = nil, password = nil, site = Site::NoSite)
     proxy = Proxy.restore_or_initialize host: host, port: port
 
     return if fix_source_conflicts(proxy).conflict_exists?
     proxy.source = self
+    proxy.username = username
+    proxy.password = password
     proxy.save
     site.add_proxies(proxy)
   end

--- a/app/models/sources/fog.rb
+++ b/app/models/sources/fog.rb
@@ -181,7 +181,7 @@ module Sources
     # Parameters:
     #   site - What site to add the found servers to (if any)
     def save_server(server, *args)
-      add_proxy(server.public_ip_address, config['proxy_port'], *args)
+      add_proxy(server.public_ip_address, config['proxy_port'], nil, nil, *args)
     end
   end
 end

--- a/app/models/sources/static.rb
+++ b/app/models/sources/static.rb
@@ -1,0 +1,50 @@
+module Sources
+  class Static < Source
+    def decommission_proxy(proxy)
+      # Do nothing. The Proxy instance is already going to be deleted.
+    end
+    
+    def provision_proxies(desired_proxy_count, site)
+      # Do nothing. There's no automatic way to provision proxies from a static list.
+    end
+    
+    def validate_config!
+      true  # No config to validate
+    end
+    
+    def max_proxies
+      0  # Never try to provision extra proxies from a static list
+    end
+    
+    def load_from_file(path, site = Site::NoSite)
+      open(path, 'r').each_line do |proxy_spec|
+        proxy_spec.strip!
+        next if proxy_spec.empty? or proxy_spec =~ /^#/
+        
+        host, port, username, password = nil, nil, nil, nil
+        case proxy_spec
+        when /^(.+):(.+)@([0-9.]+):([0-9]+)$/
+          host = $3
+          port = $4.to_i
+          username = $1
+          password = $2
+        when /^([0-9.]+):([0-9]+)$/
+          host = $1
+          port = $2.to_i
+        else
+          add_error "Invalid proxy specification: #{proxy_spec}"
+          next
+        end
+        
+        unless self.proxies.active.where(host: host, port: port).count > 0
+          add_proxy(host, port, username, password, site)
+        end
+      end
+    end
+    
+    class << self
+      def required_fields; {}; end
+      def display_name; "Static List"; end
+    end
+  end
+end

--- a/db/migrate/20150818204936_add_username_and_password_to_proxies.rb
+++ b/db/migrate/20150818204936_add_username_and_password_to_proxies.rb
@@ -1,0 +1,6 @@
+class AddUsernameAndPasswordToProxies < ActiveRecord::Migration
+  def change
+    add_column :proxies, :username, :string
+    add_column :proxies, :password, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150320185058) do
+ActiveRecord::Schema.define(version: 20150818204936) do
 
   create_table "api_keys", force: :cascade do |t|
     t.string   "uuid"
@@ -26,6 +26,8 @@ ActiveRecord::Schema.define(version: 20150320185058) do
     t.datetime "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string   "username"
+    t.string   "password"
   end
 
   add_index "proxies", ["deleted_at"], name: "index_proxies_on_deleted_at"

--- a/lib/zartan/source_type.rb
+++ b/lib/zartan/source_type.rb
@@ -6,7 +6,8 @@ module Zartan
       [
         ::Sources::DigitalOcean,
         ::Sources::Linode,
-        ::Sources::Joyent
+        ::Sources::Joyent,
+        ::Sources::Static
       ]
     end
   end

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Source, type: :model do
       expect(source).to receive(:fix_source_conflicts).and_return(conflict)
       expect(site).to receive(:add_proxies)
 
-      source.send(:add_proxy, proxy.host, proxy.port, site)
+      source.send(:add_proxy, proxy.host, proxy.port, nil, nil, site)
       expect(proxy.source).to be source
     end
 
@@ -109,7 +109,7 @@ RSpec.describe Source, type: :model do
       conflict = double(:conflict_exists? => true)
       expect(source).to receive(:fix_source_conflicts).and_return(conflict)
 
-      source.send(:add_proxy, proxy.host, proxy.port, site)
+      source.send(:add_proxy, proxy.host, proxy.port, nil, nil, site)
       expect(proxy.source).to_not be source
     end
   end


### PR DESCRIPTION
Add a new `Source` subclass for managing static lists of proxies.

Currently, there is no way to manage the list beyond opening up the console and fiddling around with the `Proxy` objects, but a proper management tool is on the radar.